### PR TITLE
Organize recordings into language/task bins

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,11 +16,12 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-mic": "^12.4.6",
-        "react-scripts": "^5.0.1",
+        "react-scripts": "5.0.1",
         "react-youtube": "^10.1.0"
       },
       "devDependencies": {
-        "react-router-dom": "^6.21.1"
+        "react-router-dom": "^6.21.1",
+        "sass": "^1.71.0"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -9969,8 +9970,7 @@
       "version": "4.3.7",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.7.tgz",
       "integrity": "sha512-1hqclzwYwjRDFLjcFxOM5AYkkG0rpFPpr1RLPMEuGczoS7YA8gLhy8SWXYRAA/XwfEHpfo3cw5JGioS32fnMRw==",
-      "optional": true,
-      "peer": true
+      "devOptional": true
     },
     "node_modules/import-fresh": {
       "version": "3.3.0",
@@ -16600,8 +16600,7 @@
       "version": "1.77.8",
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.77.8.tgz",
       "integrity": "sha512-4UHg6prsrycW20fqLGPShtEvo/WyHRVRHwOP4DzkUrObWoWI05QBSfzU71TVB7PFaL104TwNaHpjlWXAZbQiNQ==",
-      "optional": true,
-      "peer": true,
+      "devOptional": true,
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0",
         "immutable": "^4.0.0",

--- a/src/Components/VideoRecorder.js
+++ b/src/Components/VideoRecorder.js
@@ -1,9 +1,10 @@
 import React, { useEffect, useRef, useState } from "react";
 import { APIBASEURL } from "../config";
+import { buildRecordingBin } from "../utils/recordingBins";
 
 const VIDEO_MIME = "video/webm"; // typical MediaRecorder output
 
-const VideoRecorder = () => {
+const VideoRecorder = ({ language, task = "user-uploaded-video" }) => {
   const [devices, setDevices] = useState([]);
   const [selectedDeviceIds, setSelectedDeviceIds] = useState([]);
   const [streams, setStreams] = useState([]);
@@ -153,6 +154,14 @@ const VideoRecorder = () => {
       formData.append(
         "participantid",
         localStorage.getItem("username") || ""
+      );
+      formData.append(
+        "bucketName",
+        buildRecordingBin({
+          language,
+          task,
+          source: "user-uploaded-recording",
+        })
       );
       formData.append("source", "browser-multi-camera");
 

--- a/src/Components/VideoUpload.js
+++ b/src/Components/VideoUpload.js
@@ -1,9 +1,10 @@
 import React, { useState } from "react";
 import { APIBASEURL } from "../config";
+import { buildRecordingBin } from "../utils/recordingBins";
 
 const DESIRED_TYPE = "video/mp4"; // backend can convert if different
 
-const VideoUpload = () => {
+const VideoUpload = ({ language, task = "user-uploaded-video" }) => {
   const [file, setFile] = useState(null);
   const [error, setError] = useState("");
   const [uploading, setUploading] = useState(false);
@@ -39,6 +40,15 @@ const VideoUpload = () => {
         "participantid",
         localStorage.getItem("username") || ""
       );
+      formData.append(
+        "bucketName",
+        buildRecordingBin({
+          language,
+          task,
+          source: "user-uploaded-recording",
+        })
+      );
+      formData.append("source", "browser-upload");
 
       const res = await fetch(`${APIBASEURL}/video-upload`, {
         method: "POST",

--- a/src/StoryTest/Retell.js
+++ b/src/StoryTest/Retell.js
@@ -160,8 +160,8 @@ const Retell = ({
 
       <div style={{ marginTop: 32 }}>
         <h2>{showChinese ? "视频回答选项" : "Video response options"}</h2>
-        <VideoRecorder />
-        <VideoUpload />
+        <VideoRecorder language={showChinese ? "CN" : "EN"} task="story-retell" />
+        <VideoUpload language={showChinese ? "CN" : "EN"} task="story-retell" />
       </div>
 
       <div style={{ marginTop: 16 }}>

--- a/src/StoryTest/StoryTest.js
+++ b/src/StoryTest/StoryTest.js
@@ -16,6 +16,7 @@ import Confirmation from "../Components/Confirmation";
 import Instructions from "./Instructions";
 import AudioPermission from "../Tests/AudioPermission";
 import { APIBASEURL } from "../config";
+import { buildRecordingBin } from "../utils/recordingBins";
 
 let questionAudio;
 let audioLink;
@@ -252,10 +253,13 @@ const StoryTest = ({ language }) => {
       audioData: base64Data,
       userId: localStorage.getItem("username"),
       questionId,
-      bucketName:
-        type === "retell"
-          ? `merls-story-user-audio/retell/${currentStory}`
-          : `merls-story-user-audio/question/${currentStory}`,
+      bucketName: buildRecordingBin({
+        showChinese,
+        task: type === "retell" ? "story-retell" : "story-question",
+        source: "system-recording",
+        storyId: currentStory,
+        questionId,
+      }),
     };
 
     const response = await fetch(LAMBDAAPIENDPOINT, {

--- a/src/Tests/Test.js
+++ b/src/Tests/Test.js
@@ -15,6 +15,7 @@ import CompletionPage from "./CompletionPage";
 import GreenButton from "../Components/GreenButton";
 import { APIBASEURL } from "../config";
 import { isChineseLanguage, isEnglishLanguage } from "../utils/language";
+import { buildRecordingBin } from "../utils/recordingBins";
 
 const LAMBDAAPIENDPOINT = `${APIBASEURL}/audio-upload`;
 
@@ -111,7 +112,11 @@ const Test = ({ type, language }) => {
         audioData: base64Data,
         userId: localStorage.getItem("username"),
         questionId,
-        bucketName: "merls-audio",
+        bucketName: buildRecordingBin({
+          isChinese,
+          task: type,
+          source: "system-recording",
+        }),
       };
 
       const response = await fetch(LAMBDAAPIENDPOINT, {

--- a/src/utils/recordingBins.js
+++ b/src/utils/recordingBins.js
@@ -1,0 +1,47 @@
+const normalizeLanguageBin = ({ language, showChinese, isChinese } = {}) => {
+  // Makes sure the right bin is chosen from the current task and language settings. Returns "english" or "chinese".
+  if (typeof language === "string") {
+    const normalized = language.trim().toLowerCase();
+
+    if (normalized === "cn" || normalized === "zh" || normalized.startsWith("zh-")) {
+      return "chinese";
+    }
+
+    if (normalized === "en" || normalized.startsWith("en-")) {
+      return "english";
+    }
+  }
+
+  if (typeof showChinese === "boolean") {
+    return showChinese ? "chinese" : "english";
+  }
+
+  if (typeof isChinese === "boolean") {
+    return isChinese ? "chinese" : "english";
+  }
+
+  return "english";
+};
+
+export const buildRecordingBin = ({
+  language,
+  showChinese,
+  isChinese,
+  task,
+  source = "system-recording",
+  storyId,
+  questionId,
+} = {}) => {
+  const languageBin = normalizeLanguageBin({ language, showChinese, isChinese });
+  const segments = ["recordings", languageBin, task, source].filter(Boolean);
+
+  if (storyId !== undefined && storyId !== null && storyId !== "") {
+    segments.push(`story-${storyId}`);
+  }
+
+  if (questionId !== undefined && questionId !== null && questionId !== "") {
+    segments.push(`question-${questionId}`);
+  }
+
+  return segments.join("/");
+};


### PR DESCRIPTION
Organized the recordings into the following bins for easier access: 

recordings/english/matching/system-recording
recordings/chinese/matching/system-recording
recordings/english/repetition/system-recording
recordings/chinese/repetition/system-recording
recordings/english/story-question/system-recording/story-N/question-M
recordings/chinese/story-question/system-recording/story-N/question-M
recordings/english/story-retell/system-recording/story-N/question-M
recordings/chinese/story-retell/system-recording/story-N/question-M
recordings/english/story-retell/user-uploaded-recording
recordings/chinese/story-retell/user-uploaded-recording 

** N and M get filled in with the correct story and question IDs dynamically ** 